### PR TITLE
added blog subfolder redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/blog"
+  to = "https://sirlisko.com/blog/"
+  status = 200
+  force = true


### PR DESCRIPTION
Added `/blog` redirect for netlify hosting service.

See https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file for more details.